### PR TITLE
libs/cairo: Fix build and upgrade to 1.16.0

### DIFF
--- a/recipes/libs/cairo.yaml
+++ b/recipes/libs/cairo.yaml
@@ -1,7 +1,7 @@
 inherit: [autotools]
 
 metaEnvironment:
-    PKG_VERSION: "1.14.12"
+    PKG_VERSION: "1.16.0"
 
 depends:
     - libs::libpng-dev
@@ -9,7 +9,6 @@ depends:
     - libs::zlib-dev
     - libs::freetype-dev
     - libs::fontconfig-dev
-
     - use: []
       depends:
           - libs::libpng-tgt
@@ -21,9 +20,10 @@ depends:
 checkoutSCM:
     scm: url
     url:  https://www.cairographics.org/releases/cairo-${PKG_VERSION}.tar.xz
-    digestSHA256: 8c90f00c500b2299c0a323dd9beead2a00353752b2092ead558139bd67f7bf16
+    digestSHA256: 5e7b29b3f113ef870d1e3ecf8adf21f923396401604bda16d44be45e66052331
     stripComponents: 1
 
+buildTools: [host-toolchain]
 buildScript: |
     export png_REQUIRES="libpng"
     autotoolsBuild $1 \


### PR DESCRIPTION
The cairo recipe fails with: strings: command not found
Therefore we add the binutils tools providing the strings command.

Also upgrade to the latest version that is available for direct
download at the projects website.