### PR TITLE
core/busybox: Allow custom configuration

### DIFF
--- a/recipes/core/busybox.yaml
+++ b/recipes/core/busybox.yaml
@@ -1,5 +1,9 @@
 inherit: [make]
 
+depends:
+    - if: "${BUSYBOX_CUSTOM_CONFIG:-}"
+      name: core::busybox-custom-config
+
 metaEnvironment:
     PKG_VERSION: "1.35.0"
 
@@ -10,14 +14,20 @@ checkoutSCM:
     stripComponents: 1
 
 buildTools: [host-toolchain, target-toolchain]
-buildVars: [ARCH, CROSS_COMPILE, CFLAGS, LDFLAGS]
+buildVars: [ARCH, BUSYBOX_CUSTOM_CONFIG, CFLAGS, CROSS_COMPILE, LDFLAGS]
 buildScript: |
     # prevent timestamps in configuration
     export KCONFIG_NOTIMESTAMP=1
 
     mkdir -p build install
     cd build
-    make -C $1 O=$PWD defconfig
+
+    if [[ ${BUSYBOX_CUSTOM_CONFIG:+true} ]] ; then
+        cp -u "${BOB_DEP_PATHS[core::busybox-custom-config]}/${BUSYBOX_CUSTOM_CONFIG}" .config
+        make -C $1 O=$PWD oldconfig
+    else
+        make -C $1 O=$PWD defconfig
+    fi
     makeParallel
     make CONFIG_PREFIX=${BOB_CWD}/install install
 


### PR DESCRIPTION
The current approach builds all available (non-debug) features into
Busybox. Not only can the resulting binary be too large depending on
the use-case, you also have to ensure that the symlinks provided by
Busybox don't collide with your actual programs provided by other
packages while packing the root file system.

Analogous to kernel::linux, this commit thus opens the possibility to
bring your own config for Busybox and disable features you don't need.
It has to be provided in the dist directory of a package named
core::busybox-custom-config. The file name of the config has to be
stored in ${BUSYBOX_CUSTOM_CONFIG}.