### PR TITLE
utils/e2fsprogs: Add host-toolchain

### DIFF
--- a/recipes/utils/e2fsprogs.yaml
+++ b/recipes/utils/e2fsprogs.yaml
@@ -9,6 +9,7 @@ checkoutSCM:
     digestSHA256: "65faf6b590ca1da97440d6446bd11de9e0914b42553740ba5d9d2a796fa0dc02"
     stripComponents: 1
 
+buildTools: [host-toolchain]
 buildScript: |
     autotoolsBuild $1
 


### PR DESCRIPTION
Otherwise cross-compiling fails with

```
[  75] |utils::e2fsprogs| make[1]: Leaving directory '/bob/cd8e3c1ec9a5edbd24ab417832a196e1796b8768/workspace/build'
[  75] |utils::e2fsprogs| /bob/a21624a3af225641b383a26df8320bc4d2445605/workspace/config/parse-types.sh: line 116: -o: command not found
[  75] |utils::e2fsprogs| /bob/a21624a3af225641b383a26df8320bc4d2445605/workspace/config/parse-types.sh: line 117: ./asm_types: No such file or directory
[  75] |utils::e2fsprogs| rm: cannot remove 'asm_types': No such file or directory
```