### PR TITLE
devel/squashfs-tools: Upgrade to 4.5.1

### DIFF
--- a/recipes/devel/squashfs-tools.yaml
+++ b/recipes/devel/squashfs-tools.yaml
@@ -1,7 +1,7 @@
 inherit: [autotools]
 
 metaEnvironment:
-    PKG_VERSION: "4.4"
+    PKG_VERSION: "4.5.1"
 
 depends:
     - utils::xz-utils-dev
@@ -10,19 +10,22 @@ depends:
 checkoutSCM:
     scm: url
     url: ${GITHUB_MIRROR}/plougher/squashfs-tools/archive/${PKG_VERSION}.tar.gz
-    digestSHA256: "a7fa4845e9908523c38d4acf92f8a41fdfcd19def41bd5090d7ad767a6dc75c3"
+    digestSHA256: "277b6e7f75a4a57f72191295ae62766a10d627a4f5e5f19eadfbc861378deea7"
     stripComponents: 1
 
-buildVars: [CC, CPPFLAGS, CFLAGS, LDFLAGS]
+buildVars: [CC]
 buildScript: |
-    CFLAGS+=" -I${BOB_DEP_PATHS[utils::xz-utils-dev]}/usr/include -I${BOB_DEP_PATHS[libs::zlib-dev]}/usr/include"
-    LDFLAGS+=" -L${BOB_DEP_PATHS[utils::xz-utils-dev]}/usr/lib -L${BOB_DEP_PATHS[libs::zlib-dev]}/usr/lib"
+    mkdir -p build install
 
+    OLD_PWD="${PWD}"
+
+    pushd build
     rsync -aH --delete $1/ .
-    make -C squashfs-tools CC=${CC}
+    makeParallel -C squashfs-tools
+    makeSequential -C squashfs-tools install INSTALL_PREFIX="${OLD_PWD}/install/usr/"
+    popd
 
-packageScript: |
-    make -C $1/squashfs-tools install INSTALL_DIR=${PWD}/usr/local/bin
+packageScript: autotoolsPackageTgt
 
 provideTools:
-    squashfs-tools: "usr/local/bin"
+    squashfs-tools: "usr/bin"


### PR DESCRIPTION
Besides a security fix for CVE-2021-41072 this upgrade brings successful compilation back to squashfs-tools, after the recent GCC upgrade broke it (see https://github.com/plougher/squashfs-tools/pull/83).