### PR TITLE
devel/dtc: Add AR to buildVars

### DIFF
--- a/recipes/devel/dtc.yaml
+++ b/recipes/devel/dtc.yaml
@@ -10,7 +10,7 @@ checkoutSCM:
   stripComponents: 1
 
 buildTools: [bison, flex, target-toolchain]
-buildVars: [CC, LD, CFLAGS, LDFLAGS]
+buildVars: [AR, CC, LD, CFLAGS, LDFLAGS]
 buildScript: |
   mkdir -p build install
   rsync -a "$1/" build/


### PR DESCRIPTION
This adds AR to the buildVars in devel/dtc, because otherwise it complains that `ar` is an unknown command.

@jkloetzke 