### PR TITLE
rootfs: add shell-tables + fixes

### DIFF
--- a/classes/rootfs.yaml
+++ b/classes/rootfs.yaml
@@ -115,6 +115,20 @@ buildSetup: |
         fi
     }
 
+    # Create the final shell-table file. It searches all provided source paths
+    # for *.shell-tables files within the .bob directories.
+    #
+    # $1: source path to search for *.shell-table files
+    # $2: output file
+    rootfsMergeShellTables()
+    {
+        # Search for all shell-table files and cat them into one file
+        TABLES=`find "${@:2}" -regex ".bob/.*.shell-table"`
+        if [ "$TABLES" != "" ]; then
+          cat $TABLES > "$1"
+        fi
+    }
+
     # Execute commonly required task on the root fs directory. This is in
     # preparation of the actual image creation step.
     #
@@ -136,6 +150,9 @@ buildSetup: |
 
         # Search for all device-table files and cat them into one file
         rootfsMergeDeviceTables $DEVICE_TABLE_FILE "${@:2}"
+
+        # Search for all shell-table files and cat them into one file
+        rootfsMergeShellTables $1/etc/shells "${@:2}"
 
         # call depmod on the final tree
         if [ -e $1/lib/modules/* ]; then

--- a/recipes/core/busybox.yaml
+++ b/recipes/core/busybox.yaml
@@ -1,4 +1,4 @@
-inherit: [make]
+inherit: [make, install]
 
 depends:
     - if: "${BUSYBOX_CUSTOM_CONFIG:-}"
@@ -31,6 +31,18 @@ buildScript: |
     makeParallel
     make CONFIG_PREFIX=${BOB_CWD}/install install
 
-packageScript: |
-    cp -a $1/install/* .
+    mkdir -p install/.bob
 
+    # busybox must be setuid if configured
+    grep -qE '^CONFIG_FEATURE_SUID=y$' build/.config && \
+        printf '/usr/bin/busybox f 4755 0  0 - - - - -\n' > install/.bob/busybox.device-table
+
+    # add configured shells
+    (
+        printf '/bin/sh\n/usr/bin/sh\n'
+        grep -qE '^CONFIG_SHELL_ASH=y$' build/.config && printf '/bin/ash\n/usr/bin/ash\n'
+        grep -qE '^CONFIG_SHELL_HUSH=y$' build/.config && printf '/bin/hush\n/usr/bin/hush\n'
+    ) > install/.bob/busybox.shell-table
+
+packageScript: |
+    installCopy "$1/install/"

--- a/recipes/net/openssh.yaml
+++ b/recipes/net/openssh.yaml
@@ -26,6 +26,13 @@ buildScript: |
         --with-ssl-dir="${BOB_DEP_PATHS[libs::openssl-dev]}/usr" \
         --without-openssl-header-check
 
+    mkdir -p install/.bob
+
+    # add some daemon users
+    cat >install/.bob/sshd.user-table <<EOF
+    sshd -1 sshd -1 * - - - sshd user
+    EOF
+
 packageScript: |
     autotoolsPackageTgt
 

--- a/recipes/net/openssh.yaml
+++ b/recipes/net/openssh.yaml
@@ -1,7 +1,7 @@
 inherit: [autotools]
 
 metaEnvironment:
-    PKG_VERSION: "9.8p1"
+    PKG_VERSION: "9.9p1"
 
 depends:
     - libs::openssl-dev
@@ -15,7 +15,7 @@ depends:
 checkoutSCM:
     scm: url
     url: http://ftp.openbsd.org/pub/OpenBSD/OpenSSH/portable/openssh-${PKG_VERSION}.tar.gz
-    digestSHA1: "a0bb501b11349f5c5c33a269351be091dc2c2727"
+    digestSHA1: 5ded7eb0add0b02b5d1a1c4bf5cb2c89d2117b53
     stripComponents: 1
 
 buildTools: [target-toolchain]

--- a/recipes/utils/screen.yaml
+++ b/recipes/utils/screen.yaml
@@ -1,28 +1,29 @@
-inherit: [autotools, patch]
+inherit: [autotools]
 
 metaEnvironment:
-  PKG_VERSION: 5.0.0
+    PKG_VERSION: 5.0.0
 
 checkoutSCM:
-  scm: url
-  url: https://ftp.gnu.org/gnu/screen/screen-${PKG_VERSION}.tar.gz
-  digestSHA256: f04a39d00a0e5c7c86a55338808903082ad5df4d73df1a2fd3425976aed94971
-  stripComponents: 1
+    scm: url
+    url: ${GNU_MIRROR}/screen/screen-${PKG_VERSION}.tar.gz
+    digestSHA256: f04a39d00a0e5c7c86a55338808903082ad5df4d73df1a2fd3425976aed94971
+    stripComponents: 1
 
 depends:
-  - libs::libxcrypt-dev
-  - libs::ncurses-dev
-  - use: []
-    depends:
-      - libs::libxcrypt-tgt
-      - libs::ncurses-tgt
+    - libs::libxcrypt-dev
+    - libs::ncurses-dev
+    - use: []
+      depends:
+        - libs::libxcrypt-tgt
+        - libs::ncurses-tgt
 
 buildScript: |
-  CFLAGS="${CFLAGS} -I$1"
-  autotoolsBuild $1 --prefix=/usr \
-          --sysconfdir=/etc \
-          --disable-pam
+    CFLAGS="${CFLAGS} -I$1"
+    autotoolsBuild $1 \
+        --prefix=/usr \
+        --sysconfdir=/etc \
+        --disable-pam
 
 provideDeps: ["*-tgt"]
 packageScript: |
-  autotoolsPackageTgt
+    autotoolsPackageTgt

--- a/recipes/utils/screen.yaml
+++ b/recipes/utils/screen.yaml
@@ -24,6 +24,14 @@ buildScript: |
         --sysconfdir=/etc \
         --disable-pam
 
+    mkdir -p install/.bob
+
+    # add screen as shell
+    cat >install/.bob/screen.shell-table <<EOF
+    /bin/screen
+    /usr/bin/screen
+    EOF
+
 provideDeps: ["*-tgt"]
 packageScript: |
     autotoolsPackageTgt

--- a/recipes/virt/libjpeg.yaml
+++ b/recipes/virt/libjpeg.yaml
@@ -1,13 +1,12 @@
-depends:
-    - ${CONFIG_SELECT_LIBJPEG:-libs::jpeg-turbo}-dev
-
-    - use: []
-      depends:
-          - ${CONFIG_SELECT_LIBJPEG:-libs::jpeg-turbo}-tgt
-
 multiPackage:
     dev:
-        provideDeps: [ "*-dev" ]
+        depends:
+            - name: ${CONFIG_SELECT_LIBJPEG:-libs::jpeg-turbo}-dev
+              use: []
 
     tgt:
-        provideDeps: [ "*-tgt" ]
+        depends:
+            - name: ${CONFIG_SELECT_LIBJPEG:-libs::jpeg-turbo}-tgt
+              use: []
+
+provideDeps: [ "*" ]


### PR DESCRIPTION
Search for *.shell-table files in the .bob directories and cat them into one /etc/shells. Some login tools check for the existence of an entry for the used shell in /etc/shells. Packages which provide shells, can simply create such a file with an appropriate entry.