### PR TITLE
net::openssh: add libxcrypt dependency

### DIFF
--- a/recipes/net/openssh.yaml
+++ b/recipes/net/openssh.yaml
@@ -4,11 +4,13 @@ metaEnvironment:
     PKG_VERSION: "9.9p1"
 
 depends:
+    - libs::libxcrypt-dev
     - libs::openssl-dev
     - libs::zlib-dev
 
     - use: []
       depends:
+        - libs::libxcrypt-tgt
         - libs::openssl-tgt
         - libs::zlib-tgt
 


### PR DESCRIPTION
Since glibc 2.39 it doesn't come with a libcrypt anymore. This means sshd had no support for password decryption methods beside md5 and openssl des.

This broke sshd login support e.g. with the rootfs support class, because this uses sha-512 encryption of the user passwords.

Fix this by adding libxcrypt as dependency which provides this functionality to openssh again.