### PR TITLE
classes::rootfs::ext4: make size handling more versatile

### DIFF
--- a/classes/rootfs.yaml
+++ b/classes/rootfs.yaml
@@ -164,7 +164,7 @@ buildSetup: |
         # Create a base script which we can execute in a fake root environment.
         # This can be used by the actual scripts creating the target files.
         read -r -d '\0' CREATE_SH_FILE << EOF
-    #!/bin/sh
+    #!/bin/bash
     set -e
     chown -h -R 0:0 $1
     if [ -e $USER_TABLE_FILE ]; then

--- a/classes/rootfs/ext4.yaml
+++ b/classes/rootfs/ext4.yaml
@@ -15,14 +15,38 @@ buildSetup: |
     # $1: rootfs source directory
     # $2: output name
     # $3: output size (optional)
+    #     This can be:
+    #     - nothing: auto calc size + head room (18%)
+    #     - number:  absolute overall size in kbytes
+    #     - number%: percentage in the form of 1.20% to add 20%
+    #     - number+: absolute free space in kbytes in the form of 1024+ to add 1MB
     rootfsExt4CreateImage()
     {
+        SIZE=${3:-1.18%}
+        if [[ $SIZE == *% ]]; then
+            # automatic: calc size and add head room/free space in % as specified
+            # by the user
+            SIZE="\$(dir_size_in_kb $1 ${SIZE%\%})"
+        elif [[ $SIZE == *+ ]]; then
+            # automatic: calc size and add head room/free space in absolute bytes
+            # as specified by the user
+            SIZE="\$(dir_size_in_kb $1 1 ${SIZE%\+})"
+        fi # default: manually specified
+
         cat >create_ext4_img.sh <<EOF
     $CREATE_SH_FILE
 
-    # calc size and add 18% head room for inodes, ...
-    SIZE=${3:-\$(printf %0.f \$(echo "\$(du -xsb -- install | cut -f 1)*1.18" | bc) | numfmt --to-unit=1024)}
-    mkfs.ext4 -d $1 $BOB_CWD/$2.img \${SIZE}
+    # return size of dir in kbytes
+    #
+    # \$1: source dir
+    # \$2: multiply by factor (optional; default 1)
+    # \$3: add additional size in kb (optional; default 0)
+    function dir_size_in_kb()
+    {
+        printf %0.f \$(echo "\$(du -xsb -- \$1 | cut -f 1)*\${2:-1}+\${3:-0}*1024" | bc) | numfmt --to-unit=1024
+    }
+
+    mkfs.ext4 -d $1 $BOB_CWD/$2.img $SIZE
     EOF
 
         FAKEROOTDONTTRYCHOWN=1 fakeroot -- sh create_ext4_img.sh


### PR DESCRIPTION
There a multiple use cases on how to set the final image size. One may not care at all, others may want to specify a certain percentage of free space and than others may want to specify the exact size. Those different use cases can now be expressed with the following:

$3: output size (optional)
   This can be:
   - nothing: auto calc size + head room (18%)
   - number:  absolute overall size in kbytes
   - number%: percentage in the form of 1.20% to add 20%
   - number+: absolute free space in kbytes in the form of 1024+ to add 1MB