### PR TITLE
utils/e2fsprogs: Avoid sbrk() usage

### DIFF
--- a/recipes/utils/e2fsprogs.yaml
+++ b/recipes/utils/e2fsprogs.yaml
@@ -1,4 +1,4 @@
-inherit: [autotools]
+inherit: [autotools, patch]
 
 metaEnvironment:
     PKG_VERSION: "1.47.1"
@@ -8,6 +8,10 @@ checkoutSCM:
     url: ${KERNEL_MIRROR}/linux/kernel/people/tytso/e2fsprogs/v${PKG_VERSION}/e2fsprogs-${PKG_VERSION}.tar.xz
     digestSHA256: "5a33dc047fd47284bca4bb10c13cfe7896377ae3d01cb81a05d406025d99e0d1"
     stripComponents: 1
+
+checkoutDeterministic: True
+checkoutScript: |
+    patchApplySeries $<@e2fsprogs/*.patch@>
 
 buildTools: [host-toolchain]
 buildScript: |

--- a/recipes/utils/e2fsprogs/0001-e2fsprogs-resize-resource-track.patch
+++ b/recipes/utils/e2fsprogs/0001-e2fsprogs-resize-resource-track.patch
@@ -1,0 +1,41 @@
+diff -ur a/resize/resize2fs.h b/resize/resize2fs.h
+--- a/resize/resize2fs.h	2024-12-18 17:06:42.768502913 +0100
++++ b/resize/resize2fs.h	2024-12-18 17:41:59.259698891 +0100
+@@ -171,12 +171,19 @@
+ extern errcode_t online_resize_fs(ext2_filsys fs, const char *mtpt,
+ 				  blk64_t *new_size, int flags);
+ 
++#define RESOURCE_TRACK
++
+ /* resource_track.c */
++#ifdef RESOURCE_TRACK
+ extern void init_resource_track(struct resource_track *track, const char *desc,
+ 				io_channel channel);
+ extern void print_resource_track(ext2_resize_t rfs,
+ 				 struct resource_track *track,
+ 				 io_channel channel);
++#else
++#define init_resource_track(track, desc, channel) do { } while (0)
++#define print_resource_track(rfs, track, channel) do { } while (0)
++#endif
+ 
+ /* sim_progress.c */
+ extern errcode_t ext2fs_progress_init(ext2_sim_progmeter *ret_prog,
+Only in b/resize: resize2fs.h-foo
+diff -ur a/resize/resource_track.c b/resize/resource_track.c
+--- a/resize/resource_track.c	2024-12-18 17:06:42.768502913 +0100
++++ b/resize/resource_track.c	2024-12-18 17:40:47.175868997 +0100
+@@ -18,6 +18,8 @@
+ #endif
+ #include <sys/resource.h>
+ 
++#ifdef RESOURCE_TRACK
++
+ void init_resource_track(struct resource_track *track, const char *desc,
+ 			 io_channel channel)
+ {
+@@ -133,3 +135,4 @@
+ 	fflush(stdout);
+ }
+ 
++#endif /* RESOURCE_TRACK */

--- a/recipes/utils/e2fsprogs/0002-e2fsprogs-disable-resource-tracking-l4re.patch
+++ b/recipes/utils/e2fsprogs/0002-e2fsprogs-disable-resource-tracking-l4re.patch
@@ -1,0 +1,30 @@
+diff -ur a/e2fsck/e2fsck.h b/e2fsck/e2fsck.h
+--- a/e2fsck/e2fsck.h	2024-11-29 09:02:27.000000000 +0100
++++ b/e2fsck/e2fsck.h	2024-12-23 08:16:58.578786299 +0100
+@@ -145,7 +145,11 @@
+ 
+ struct encrypted_file_info;
+ 
++// Disabled as this functionality needs sbrk() which is not available
++// universally.
++#ifndef __l4re__
+ #define RESOURCE_TRACK
++#endif /* __l4re__ */
+ 
+ #ifdef RESOURCE_TRACK
+ /*
+diff -ur a/resize/resize2fs.h b/resize/resize2fs.h
+--- a/resize/resize2fs.h	2024-12-23 08:16:10.450929993 +0100
++++ b/resize/resize2fs.h	2024-12-23 08:17:37.198671023 +0100
+@@ -171,7 +171,11 @@
+ extern errcode_t online_resize_fs(ext2_filsys fs, const char *mtpt,
+ 				  blk64_t *new_size, int flags);
+ 
++// Disabled as this functionality needs sbrk() which is not available
++// universally.
++#ifndef __l4re__
+ #define RESOURCE_TRACK
++#endif /* __l4re__ */
+ 
+ /* resource_track.c */
+ #ifdef RESOURCE_TRACK


### PR DESCRIPTION
Further guard the resource tracking feature of e2fsprogs and disable its usage such that no calls to sbrk() are emitted. sbrk() is not universally available on all environments.