### PR TITLE
libxslt: explicit disable crypto

### DIFF
--- a/recipes/libs/libxslt.yaml
+++ b/recipes/libs/libxslt.yaml
@@ -21,7 +21,8 @@ buildScript: |
     autotoolsBuild $1 \
         --without-plugins \
         --without-debug \
-        --without-python
+        --without-python \
+        --without-crypto
 
 multiPackage:
     dev:


### PR DESCRIPTION
Disable use of crypto as gcrypt to avoid using the host gcrypt library when building without sandbox.