### PR TITLE
kernel/linux: make custom kernel config pkg configurable

### DIFF
--- a/recipes/kernel/linux.yaml
+++ b/recipes/kernel/linux.yaml
@@ -8,7 +8,7 @@ inherit: [make, patch]
 
 depends:
     - if: "${LINUX_CUSTOM_CONFIG:-}"
-      name: kernel::linux-custom-config
+      name: "${LINUX_CUSTOM_CONFIG_PKG:-kernel::linux-custom-config}"
 
 metaEnvironment:
     PKG_VERSION: "6.6.17"


### PR DESCRIPTION
Make the package name, where the custom kernel configuration is located configurable. Keep the old default name to avoid breaking existing setups.