### PR TITLE
rootfs: use bash in fakeroot environment

### DIFF
--- a/classes/rootfs/cpio.yaml
+++ b/classes/rootfs/cpio.yaml
@@ -24,5 +24,5 @@ buildSetup: |
          gzip > $BOB_CWD/$2.cpio.gz
     EOF
 
-        FAKEROOTDONTTRYCHOWN=1 fakeroot -- sh create_cpio_img.sh
+        FAKEROOTDONTTRYCHOWN=1 fakeroot -- bash create_cpio_img.sh
     }

--- a/classes/rootfs/ext4.yaml
+++ b/classes/rootfs/ext4.yaml
@@ -49,5 +49,5 @@ buildSetup: |
     mkfs.ext4 -d $1 $BOB_CWD/$2.img $SIZE
     EOF
 
-        FAKEROOTDONTTRYCHOWN=1 fakeroot -- sh create_ext4_img.sh
+        FAKEROOTDONTTRYCHOWN=1 fakeroot -- bash create_ext4_img.sh
     }

--- a/classes/rootfs/tar.yaml
+++ b/classes/rootfs/tar.yaml
@@ -13,5 +13,5 @@ buildSetup: |
     tar -C $1 -cJf $BOB_CWD/$2.tar.xz .
     EOF
 
-        FAKEROOTDONTTRYCHOWN=1 fakeroot -- sh create_tar_img.sh
+        FAKEROOTDONTTRYCHOWN=1 fakeroot -- bash create_tar_img.sh
     }

--- a/classes/rootfs/vfat.yaml
+++ b/classes/rootfs/vfat.yaml
@@ -50,5 +50,5 @@ buildSetup: |
     mcopy -i $2.img -s $1/* ::
     EOF
 
-        FAKEROOTDONTTRYCHOWN=1 fakeroot -- sh create_vfat_img.sh
+        FAKEROOTDONTTRYCHOWN=1 fakeroot -- bash create_vfat_img.sh
     }


### PR DESCRIPTION
@sixtyfourktec This failed for me on Debian without sandbox where `/usr/bin/sh` is a symlink to `dash`...