### PR TITLE
bsp::grub2: Make GNULIB_URL overridable

### DIFF
--- a/recipes/bsp/grub2.yaml
+++ b/recipes/bsp/grub2.yaml
@@ -16,6 +16,11 @@ Config:
             Host platform passed as `--with-platform` to configure.
             Default: efi
         type: str
+    GNULIB_URL:
+        help: |
+            Override URL for gnulib bootstrap. This is only needed if a git repo
+            is used. Default is savannah.org.
+        type: str
 
 checkoutSCM:
     scm: url
@@ -37,7 +42,7 @@ checkoutTools:
       if: "$(eq,${GRUB2_BOOTSTRAP:-0},1)"
 
 checkoutDeterministic: True
-checkoutVars: [GRUB2_BOOTSTRAP]
+checkoutVars: [GRUB2_BOOTSTRAP, GNULIB_URL]
 checkoutScript: |
     # support overriding the scm with a git repo
     if [[ ${GRUB2_BOOTSTRAP:-0} == 1 ]]; then


### PR DESCRIPTION
The default https://git.savannah.gnu.org/git/gnulib.git is quite slow sometimes (196.00 KiB/s atm), and returned HTTP 502 from time to time the last few weeks.

Therefore allow to override `default_gnulib_url` in `bootstrap` via `GNULIB_URL` env variable.