### PR TITLE
bsp::grub2: Call updateConfigAllRecursive manually

### DIFF
--- a/recipes/bsp/grub2.yaml
+++ b/recipes/bsp/grub2.yaml
@@ -1,4 +1,7 @@
-inherit: [autotools, autoconf]
+inherit: [autotools, autoconf, "basement::update-config"]
+
+privateEnvironment:
+    APPLY_UPDATE_CONFIG: "$(if-then-else,${GRUB2_BOOTSTRAP:-0},no,yes)"
 
 metaEnvironment:
     PKG_VERSION: "2.12"
@@ -47,6 +50,7 @@ checkoutScript: |
     # support overriding the scm with a git repo
     if [[ ${GRUB2_BOOTSTRAP:-0} == 1 ]]; then
         ./bootstrap
+        updateConfigAllRecursive
     fi
 
 buildTools: [bison, flex, python3, host-toolchain, m4]


### PR DESCRIPTION
Required to make the git checkout deterministic in all cases.

Consider the following. If the bob workspace is clean (i.e. fresh checkout), the following sequence happens with regards to bsp::grub2:

```
checkout_scm
update_config
bootstrap # checks out gnulib
```

This leads to an as-is gnulib/build-aux/config.guess because it is checked out after update_config is run. If on the other hand dev/src/bsp/grub2 is not removed completely but bob still updates the workspace (e.g. after a git clean -dxf in the toplevel recipes directory), updateConfigAllRecursive will update the config files in the existing gnulib directory as well, resulting in a diff to the previous variant and therefore to an indeterministic SCM checkout.

To solve this, set APPLY_UPDATE_CONFIG to "no" and call updateConfigAllRecursive manually after bootstrap.