### PR TITLE
classes/linux: fixes for -dtbs/-kmod-dist

### DIFF
--- a/classes/linux/dtbs.yaml
+++ b/classes/linux/dtbs.yaml
@@ -13,6 +13,7 @@ buildSetup: |
         makeParallel ${1:-dtbs} "${@:2}"
     }
 
+packageVars: [LINUX_ARCH]
 packageSetup: |
     # Install the device tree files.
     #
@@ -22,7 +23,7 @@ packageSetup: |
     #       are installed
     linuxInstallDtbs()
     {
-        if [[ -n "${2:-}" ]]; then
+        if [[ ! "${2+set}" ]]; then
             if [[ -d "$1/arch/$LINUX_ARCH/boot/dts" ]] ; then
                 make -C "$1" INSTALL_DTBS_PATH="$PWD" dtbs_install
             fi

--- a/classes/linux/kmod-dist.yaml
+++ b/classes/linux/kmod-dist.yaml
@@ -1,5 +1,6 @@
 inherit: [linux]
 
+packageVars: [LINUX_ARCH]
 packageSetup: |
     _SCRIPT_DIR=$1/kmod-script
 


### PR DESCRIPTION
The LINUX_ARCH var needs to be provided in the -dtbs and -kmod-dist target. Also the test in linuxInstallDtbs was inverted.