### PR TITLE
pre-commit: only sanitize yaml files

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,8 +1,4 @@
-exclude: |
-    (?x)^(
-      .*.patch|
-      .*.diff
-    )$
+files: .*\.yaml$
 
 repos:
     - repo: https://github.com/pre-commit/pre-commit-hooks


### PR DESCRIPTION
We don't want to spell-check any other files that may be included by recipes.