### PR TITLE
libs: glib-tools build fix some libraries

### DIFF
--- a/recipes/libs/gnome/json-glib.yaml
+++ b/recipes/libs/gnome/json-glib.yaml
@@ -11,6 +11,11 @@ checkoutSCM:
     stripComponents: 1
 
 depends:
+    - name: libs::glib-tools
+      use: [tools]
+      tools:
+          target-toolchain: host-compat-toolchain
+
     - libs::glib-dev
     - use: []
       depends:

--- a/recipes/libs/harfbuzz.yaml
+++ b/recipes/libs/harfbuzz.yaml
@@ -5,6 +5,11 @@ metaEnvironment:
     PKG_LICENSE: "MIT"
 
 depends:
+    - name: libs::glib-tools
+      use: [tools]
+      tools:
+          target-toolchain: host-compat-toolchain
+
     - libs::cairo-dev
     - libs::freetype-dev
     - libs::glib-dev


### PR DESCRIPTION
Those libraries require the glib tool in the build step, however, they didn't provide a dependency for it. Fix this.