### PR TITLE
devel::gdb: Update to 17.1

### DIFF
--- a/recipes/devel/gdb.yaml
+++ b/recipes/devel/gdb.yaml
@@ -1,7 +1,7 @@
 inherit: [autotools]
 
 metaEnvironment:
-    PKG_VERSION: "16.3"
+    PKG_VERSION: "17.1"
     PKG_LICENSE: "GPL-3.0-or-later"
 
 depends:
@@ -18,7 +18,7 @@ depends:
 checkoutSCM:
     scm: url
     url: ${GNU_MIRROR}/gdb/gdb-${PKG_VERSION}.tar.xz
-    digestSHA256: "bcfcd095528a987917acf9fff3f1672181694926cc18d609c99d0042c00224c5"
+    digestSHA256: "14996f5f74c9f68f5a543fdc45bca7800207f91f92aeea6c2e791822c7c6d876"
     stripComponents: 1
 
 checkoutScript: |


### PR DESCRIPTION
This update allows building with gcc-15.